### PR TITLE
feat(carousel): implement dynamic admin-controlled homepage carousel

### DIFF
--- a/Aurakriti/src/app/admin/carousel/page.js
+++ b/Aurakriti/src/app/admin/carousel/page.js
@@ -1,0 +1,333 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+const EMPTY_FORM = {
+  title: '', subtitle: '', image: '', offerLabel: '',
+  offerPrice: '', originalPrice: '', productLink: '', ctaText: 'Shop Now',
+  isActive: true, order: 0,
+};
+
+export default function AdminCarouselPage() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [editId, setEditId] = useState(null);
+  const [imageFile, setImageFile] = useState(null);
+  const [imagePreview, setImagePreview] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [actionLoading, setActionLoading] = useState(null);
+  const [toast, setToast] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const fileRef = useRef(null);
+
+  const showToast = (msg, type = 'success') => {
+    setToast({ msg, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const fetchItems = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/admin/carousel');
+      const data = await res.json();
+      if (data.success) setItems(data.data.items);
+    } catch {
+      showToast('Failed to load carousel items', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchItems(); }, [fetchItems]);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+  };
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setEditId(null);
+    setImageFile(null);
+    setImagePreview('');
+    setShowForm(false);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  const startEdit = (item) => {
+    setForm({
+      title: item.title ?? '',
+      subtitle: item.subtitle ?? '',
+      image: item.image ?? '',
+      offerLabel: item.offerLabel ?? '',
+      offerPrice: item.offerPrice ?? '',
+      originalPrice: item.originalPrice ?? '',
+      productLink: item.productLink ?? '',
+      ctaText: item.ctaText ?? 'Shop Now',
+      isActive: item.isActive ?? true,
+      order: item.order ?? 0,
+    });
+    setEditId(item._id);
+    setImagePreview(item.image ?? '');
+    setImageFile(null);
+    setShowForm(true);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const fd = new FormData();
+      if (editId) fd.append('id', editId);
+      Object.entries(form).forEach(([k, v]) => fd.append(k, String(v)));
+      if (imageFile) fd.append('image', imageFile);
+
+      const res = await fetch('/api/admin/carousel', {
+        method: editId ? 'PATCH' : 'POST',
+        body: fd,
+      });
+      const data = await res.json();
+      if (data.success) {
+        showToast(editId ? 'Carousel item updated' : 'Carousel item created');
+        resetForm();
+        fetchItems();
+      } else {
+        showToast(data.message || 'Save failed', 'error');
+      }
+    } catch {
+      showToast('Save failed', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleActive = async (item) => {
+    setActionLoading(item._id);
+    try {
+      const fd = new FormData();
+      fd.append('id', item._id);
+      fd.append('isActive', String(!item.isActive));
+      const res = await fetch('/api/admin/carousel', { method: 'PATCH', body: fd });
+      const data = await res.json();
+      if (data.success) {
+        setItems((prev) => prev.map((i) => i._id === item._id ? { ...i, isActive: !item.isActive } : i));
+        showToast(`Item ${!item.isActive ? 'activated' : 'deactivated'}`);
+      } else {
+        showToast(data.message || 'Update failed', 'error');
+      }
+    } catch {
+      showToast('Update failed', 'error');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const deleteItem = async (id, title) => {
+    if (!confirm(`Delete "${title}"? This cannot be undone.`)) return;
+    setActionLoading(id);
+    try {
+      const res = await fetch(`/api/admin/carousel?id=${id}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (data.success) {
+        setItems((prev) => prev.filter((i) => i._id !== id));
+        showToast('Item deleted');
+      } else {
+        showToast(data.message || 'Delete failed', 'error');
+      }
+    } catch {
+      showToast('Delete failed', 'error');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const fmt = (n) => n != null ? new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', maximumFractionDigits: 0 }).format(n) : '—';
+
+  return (
+    <div className="p-6">
+      {toast && (
+        <div className={`fixed top-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-white text-sm ${toast.type === 'error' ? 'bg-red-500' : 'bg-green-500'}`}>
+          {toast.msg}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Carousel Management</h2>
+          <p className="text-gray-500 text-sm mt-1">{items.length} carousel items</p>
+        </div>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="bg-indigo-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition"
+          >
+            + Add Slide
+          </button>
+        )}
+      </div>
+
+      {/* Form */}
+      {showForm && (
+        <div className="bg-white rounded-xl shadow p-6 mb-6">
+          <h3 className="text-base font-semibold text-gray-800 mb-4">{editId ? 'Edit Slide' : 'New Slide'}</h3>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Image upload */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Slide Image</label>
+              <div className="flex items-start gap-4">
+                {imagePreview && (
+                  <img src={imagePreview} alt="preview" className="w-32 h-20 object-cover rounded-lg border" />
+                )}
+                <div className="flex-1">
+                  <input
+                    ref={fileRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleFileChange}
+                    className="block w-full text-sm text-gray-500 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+                  />
+                  <p className="text-xs text-gray-400 mt-1">Or paste an image URL below</p>
+                  <input
+                    type="url"
+                    placeholder="https://..."
+                    value={imageFile ? '' : form.image}
+                    onChange={(e) => { setForm((f) => ({ ...f, image: e.target.value })); setImagePreview(e.target.value); setImageFile(null); }}
+                    disabled={!!imageFile}
+                    className="mt-2 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-50"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Title <span className="text-red-500">*</span></label>
+                <input required value={form.title} onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Subtitle</label>
+                <input value={form.subtitle} onChange={(e) => setForm((f) => ({ ...f, subtitle: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Offer Label <span className="text-gray-400 font-normal">(e.g. "20% OFF")</span></label>
+                <input value={form.offerLabel} onChange={(e) => setForm((f) => ({ ...f, offerLabel: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">CTA Button Text</label>
+                <input value={form.ctaText} onChange={(e) => setForm((f) => ({ ...f, ctaText: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Offer Price (₹)</label>
+                <input type="number" min="0" value={form.offerPrice} onChange={(e) => setForm((f) => ({ ...f, offerPrice: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Original Price (₹)</label>
+                <input type="number" min="0" value={form.originalPrice} onChange={(e) => setForm((f) => ({ ...f, originalPrice: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Product Link</label>
+                <input type="url" placeholder="https://..." value={form.productLink} onChange={(e) => setForm((f) => ({ ...f, productLink: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Order</label>
+                <input type="number" min="0" value={form.order} onChange={(e) => setForm((f) => ({ ...f, order: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <input type="checkbox" id="isActive" checked={form.isActive}
+                onChange={(e) => setForm((f) => ({ ...f, isActive: e.target.checked }))}
+                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+              <label htmlFor="isActive" className="text-sm text-gray-700">Active (visible on homepage)</label>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button type="submit" disabled={saving}
+                className="bg-indigo-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition">
+                {saving ? 'Saving...' : editId ? 'Update Slide' : 'Create Slide'}
+              </button>
+              <button type="button" onClick={resetForm}
+                className="border border-gray-300 text-gray-700 px-5 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition">
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Items list */}
+      <div className="bg-white rounded-xl shadow overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 border-b">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">Slide</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">Offer</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">Order</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading ? (
+              <tr><td colSpan={5} className="text-center py-12 text-gray-400">Loading...</td></tr>
+            ) : items.length === 0 ? (
+              <tr><td colSpan={5} className="text-center py-12 text-gray-400">No carousel items yet. Add your first slide.</td></tr>
+            ) : items.map((item) => (
+              <tr key={item._id} className="hover:bg-gray-50">
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <img src={item.image} alt={item.title} className="w-16 h-10 object-cover rounded-lg border flex-shrink-0" />
+                    <div>
+                      <div className="font-medium text-gray-900">{item.title}</div>
+                      {item.subtitle && <div className="text-xs text-gray-500 truncate max-w-[200px]">{item.subtitle}</div>}
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  {item.offerLabel && (
+                    <span className="px-2 py-0.5 bg-amber-100 text-amber-700 rounded-full text-xs font-medium">{item.offerLabel}</span>
+                  )}
+                  {item.offerPrice != null && (
+                    <div className="text-xs text-gray-600 mt-1">
+                      {fmt(item.offerPrice)}
+                      {item.originalPrice != null && <span className="line-through text-gray-400 ml-1">{fmt(item.originalPrice)}</span>}
+                    </div>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-gray-600">{item.order}</td>
+                <td className="px-4 py-3">
+                  <button
+                    onClick={() => toggleActive(item)}
+                    disabled={actionLoading === item._id}
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium disabled:opacity-50 ${item.isActive ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}
+                  >
+                    {item.isActive ? 'Active' : 'Inactive'}
+                  </button>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-3">
+                    <button onClick={() => startEdit(item)} className="text-indigo-600 hover:text-indigo-800 text-xs font-medium">Edit</button>
+                    <button onClick={() => deleteItem(item._id, item.title)} disabled={actionLoading === item._id}
+                      className="text-red-500 hover:text-red-700 text-xs font-medium disabled:opacity-50">Delete</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/Aurakriti/src/app/admin/dashboard/page.js
+++ b/Aurakriti/src/app/admin/dashboard/page.js
@@ -68,7 +68,7 @@ export default function AdminDashboard() {
                   </div>
                 </Link>
 
-                <div className="bg-white p-6 rounded-lg shadow-md">
+                <Link href="/admin/products" className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
                   <div className="text-center">
                     <div className="bg-blue-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                       <svg className="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -77,26 +77,22 @@ export default function AdminDashboard() {
                     </div>
                     <h3 className="text-lg font-semibold text-gray-900 mb-2">Products</h3>
                     <p className="text-gray-600 text-sm mb-4">Review and moderate product listings.</p>
-                    <button className="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-blue-700">
-                      Manage Products
-                    </button>
+                    <span className="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium">Manage Products</span>
                   </div>
-                </div>
+                </Link>
 
-                <div className="bg-white p-6 rounded-lg shadow-md">
+                <Link href="/admin/carousel" className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
                   <div className="text-center">
-                    <div className="bg-purple-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <svg className="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    <div className="bg-amber-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                      <svg className="w-8 h-8 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
                     </div>
-                    <h3 className="text-lg font-semibold text-gray-900 mb-2">Analytics</h3>
-                    <p className="text-gray-600 text-sm mb-4">View platform statistics and reports.</p>
-                    <button className="bg-purple-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-purple-700">
-                      View Reports
-                    </button>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">Carousel</h3>
+                    <p className="text-gray-600 text-sm mb-4">Manage homepage carousel slides.</p>
+                    <span className="bg-amber-600 text-white px-4 py-2 rounded-md text-sm font-medium">Manage Carousel</span>
                   </div>
-                </div>
+                </Link>
               </div>
 
               {/* Admin Info */}

--- a/Aurakriti/src/app/admin/layout.js
+++ b/Aurakriti/src/app/admin/layout.js
@@ -1,0 +1,70 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useRouter, usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+const navItems = [
+  { href: '/admin/dashboard', label: 'Dashboard', icon: '🏠' },
+  { href: '/admin/users', label: 'Users', icon: '👥' },
+  { href: '/admin/sellers', label: 'Sellers', icon: '🏪' },
+  { href: '/admin/products', label: 'Products', icon: '📦' },
+  { href: '/admin/orders', label: 'Orders', icon: '🛒' },
+  { href: '/admin/carousel', label: 'Carousel', icon: '🖼️' },
+  { href: '/admin/analytics', label: 'Analytics', icon: '📊' },
+];
+
+export default function AdminLayout({ children }) {
+  const { user, isAuthenticated, initialized, logout } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!initialized) return;
+    if (!isAuthenticated || user?.role !== 'admin') {
+      router.replace('/auth/login');
+    }
+  }, [initialized, isAuthenticated, user, router]);
+
+  if (!initialized || !isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <aside className="w-56 bg-white shadow-md flex flex-col">
+        <div className="px-6 py-5 border-b">
+          <h1 className="text-lg font-bold text-indigo-700">Admin Panel</h1>
+          <p className="text-xs text-gray-500 truncate">{user.email}</p>
+        </div>
+        <nav className="flex-1 py-4">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-3 px-6 py-3 text-sm font-medium transition-colors ${
+                pathname === item.href
+                  ? 'bg-indigo-50 text-indigo-700 border-r-2 border-indigo-600'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`}
+            >
+              <span>{item.icon}</span>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="px-6 py-4 border-t">
+          <button onClick={logout} className="w-full text-sm text-red-600 hover:text-red-700 font-medium text-left">
+            Logout
+          </button>
+        </div>
+      </aside>
+      <main className="flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}

--- a/Aurakriti/src/app/api/admin/carousel/route.js
+++ b/Aurakriti/src/app/api/admin/carousel/route.js
@@ -1,0 +1,164 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/lib/db';
+import { requireRole } from '@/lib/api-auth';
+import Carousel from '@/models/Carousel';
+import { uploadBufferToCloudinary } from '@/lib/cloudinary';
+
+export const runtime = 'nodejs';
+
+// GET all carousel items (admin sees all, including inactive)
+export async function GET(request) {
+  const auth = await requireRole(request, ['admin']);
+  if (auth.error) return auth.error;
+
+  await connectDB();
+  const items = await Carousel.find().sort({ order: 1, createdAt: -1 }).lean();
+  return NextResponse.json({ success: true, data: { items } });
+}
+
+// POST create new carousel item (supports multipart/form-data for image upload)
+export async function POST(request) {
+  const auth = await requireRole(request, ['admin']);
+  if (auth.error) return auth.error;
+
+  await connectDB();
+
+  const contentType = request.headers.get('content-type') ?? '';
+  let fields = {};
+  let imageUrl = '';
+  let imagePublicId = '';
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await request.formData();
+    fields = Object.fromEntries(
+      [...formData.entries()].filter(([, v]) => !(v instanceof File))
+    );
+
+    const file = formData.get('image');
+    if (file instanceof File) {
+      if (!file.type.startsWith('image/')) {
+        return NextResponse.json({ success: false, message: 'Only image files are allowed.' }, { status: 400 });
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        return NextResponse.json({ success: false, message: 'Image must be under 5MB.' }, { status: 400 });
+      }
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const result = await uploadBufferToCloudinary(buffer, {
+        folder: 'eco-commerce/carousel',
+        public_id: `carousel-${Date.now()}`,
+      });
+      imageUrl = result.secure_url;
+      imagePublicId = result.public_id;
+    } else if (fields.image) {
+      imageUrl = fields.image;
+    }
+  } else {
+    fields = await request.json();
+    imageUrl = fields.image ?? '';
+  }
+
+  if (!fields.title?.trim()) {
+    return NextResponse.json({ success: false, message: 'Title is required.' }, { status: 400 });
+  }
+  if (!imageUrl) {
+    return NextResponse.json({ success: false, message: 'Image is required.' }, { status: 400 });
+  }
+
+  const item = await Carousel.create({
+    title: fields.title.trim(),
+    subtitle: fields.subtitle?.trim() ?? '',
+    image: imageUrl,
+    imagePublicId,
+    offerLabel: fields.offerLabel?.trim() ?? '',
+    offerPrice: fields.offerPrice ? Number(fields.offerPrice) : null,
+    originalPrice: fields.originalPrice ? Number(fields.originalPrice) : null,
+    productLink: fields.productLink?.trim() ?? '',
+    ctaText: fields.ctaText?.trim() || 'Shop Now',
+    isActive: fields.isActive !== 'false' && fields.isActive !== false,
+    order: fields.order ? Number(fields.order) : 0,
+  });
+
+  return NextResponse.json({ success: true, data: { item } }, { status: 201 });
+}
+
+// PATCH update carousel item
+export async function PATCH(request) {
+  const auth = await requireRole(request, ['admin']);
+  if (auth.error) return auth.error;
+
+  await connectDB();
+
+  const contentType = request.headers.get('content-type') ?? '';
+  let fields = {};
+  let newImageUrl = null;
+  let newImagePublicId = null;
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await request.formData();
+    fields = Object.fromEntries(
+      [...formData.entries()].filter(([, v]) => !(v instanceof File))
+    );
+
+    const file = formData.get('image');
+    if (file instanceof File && file.size > 0) {
+      if (!file.type.startsWith('image/')) {
+        return NextResponse.json({ success: false, message: 'Only image files are allowed.' }, { status: 400 });
+      }
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const result = await uploadBufferToCloudinary(buffer, {
+        folder: 'eco-commerce/carousel',
+        public_id: `carousel-${Date.now()}`,
+      });
+      newImageUrl = result.secure_url;
+      newImagePublicId = result.public_id;
+    }
+  } else {
+    fields = await request.json();
+  }
+
+  const { id, ...rest } = fields;
+  if (!id) {
+    return NextResponse.json({ success: false, message: 'id is required.' }, { status: 400 });
+  }
+
+  const update = {};
+  if (rest.title !== undefined) update.title = rest.title.trim();
+  if (rest.subtitle !== undefined) update.subtitle = rest.subtitle.trim();
+  if (rest.offerLabel !== undefined) update.offerLabel = rest.offerLabel.trim();
+  if (rest.offerPrice !== undefined) update.offerPrice = rest.offerPrice ? Number(rest.offerPrice) : null;
+  if (rest.originalPrice !== undefined) update.originalPrice = rest.originalPrice ? Number(rest.originalPrice) : null;
+  if (rest.productLink !== undefined) update.productLink = rest.productLink.trim();
+  if (rest.ctaText !== undefined) update.ctaText = rest.ctaText.trim() || 'Shop Now';
+  if (rest.isActive !== undefined) update.isActive = rest.isActive === 'true' || rest.isActive === true;
+  if (rest.order !== undefined) update.order = Number(rest.order);
+  if (newImageUrl) { update.image = newImageUrl; update.imagePublicId = newImagePublicId; }
+  else if (rest.image) update.image = rest.image;
+
+  const item = await Carousel.findByIdAndUpdate(id, update, { new: true });
+  if (!item) {
+    return NextResponse.json({ success: false, message: 'Carousel item not found.' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true, data: { item } });
+}
+
+// DELETE carousel item
+export async function DELETE(request) {
+  const auth = await requireRole(request, ['admin']);
+  if (auth.error) return auth.error;
+
+  await connectDB();
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (!id) {
+    return NextResponse.json({ success: false, message: 'id is required.' }, { status: 400 });
+  }
+
+  const item = await Carousel.findByIdAndDelete(id);
+  if (!item) {
+    return NextResponse.json({ success: false, message: 'Carousel item not found.' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true, message: 'Carousel item deleted.' });
+}

--- a/Aurakriti/src/app/api/carousel/route.js
+++ b/Aurakriti/src/app/api/carousel/route.js
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/lib/db';
+import Carousel from '@/models/Carousel';
+
+// Public: fetch active carousel items
+export async function GET() {
+  await connectDB();
+  const items = await Carousel.find({ isActive: true })
+    .sort({ order: 1, createdAt: -1 })
+    .lean();
+  return NextResponse.json({ success: true, data: { items } });
+}

--- a/Aurakriti/src/app/page.js
+++ b/Aurakriti/src/app/page.js
@@ -16,25 +16,40 @@ import { getProducts } from '@/services/productService';
 import { addToCart as addToCartRequest } from '@/services/cartService';
 import { useAuth } from '@/hooks/useAuth';
 
-// HD luxury jewellery fallback images shown while DB products load
+// HD luxury jewellery fallback images shown when no carousel items exist in DB
 const HD_HERO_FALLBACK = [
   {
     id: 'hd-1',
     image: 'https://images.unsplash.com/photo-1601121141461-9d6647bef0a0?w=1920&q=85&auto=format&fit=crop',
     title: 'Timeless Elegance',
     sub: 'Bridal jewellery crafted for your most cherished moments',
+    offerLabel: '',
+    offerPrice: null,
+    originalPrice: null,
+    productLink: '',
+    ctaText: 'Shop Now',
   },
   {
     id: 'hd-2',
     image: 'https://images.unsplash.com/photo-1573408301185-9519f94fdb85?w=1920&q=85&auto=format&fit=crop',
     title: 'Radiant by Design',
     sub: 'Discover our exclusive choker and necklace collections',
+    offerLabel: '',
+    offerPrice: null,
+    originalPrice: null,
+    productLink: '',
+    ctaText: 'Shop Now',
   },
   {
     id: 'hd-3',
     image: 'https://images.unsplash.com/photo-1535632066927-ab7c9ab60908?w=1920&q=85&auto=format&fit=crop',
     title: 'Crafted with Passion',
     sub: 'Handmade pieces that celebrate modern grace',
+    offerLabel: '',
+    offerPrice: null,
+    originalPrice: null,
+    productLink: '',
+    ctaText: 'Shop Now',
   },
 ];
 
@@ -82,6 +97,7 @@ export default function HomePage() {
   const [heroIndex, setHeroIndex] = useState(0);
   const [contactForm, setContactForm] = useState({ name: '', email: '', message: '' });
   const [trendingProducts, setTrendingProducts] = useState([]);
+  const [carouselItems, setCarouselItems] = useState([]);
 
   useEffect(() => {
     let active = true;
@@ -116,18 +132,50 @@ export default function HomePage() {
     return () => { active = false; };
   }, []);
 
-  // Hero slides: use product images when available, fall back to HD images
+  // Fetch dynamic carousel from backend
+  useEffect(() => {
+    fetch('/api/carousel')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.success && data.data.items.length > 0) {
+          setCarouselItems(data.data.items);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Hero slides: DB carousel > product images > static fallback
   const heroSlides = useMemo(() => {
-    if (!products.length) return HD_HERO_FALLBACK;
-    const featured = products.filter((p) => p.isFeatured);
-    const source = featured.length ? featured : products;
-    return source.slice(0, 4).map((p) => ({
-      id: p.id,
-      image: p.image,
-      title: p.title,
-      sub: p.description || 'Handcrafted jewellery for your special day',
-    }));
-  }, [products]);
+    if (carouselItems.length > 0) {
+      return carouselItems.map((item) => ({
+        id: item._id,
+        image: item.image,
+        title: item.title,
+        sub: item.subtitle || '',
+        offerLabel: item.offerLabel || '',
+        offerPrice: item.offerPrice,
+        originalPrice: item.originalPrice,
+        productLink: item.productLink || '',
+        ctaText: item.ctaText || 'Shop Now',
+      }));
+    }
+    if (products.length > 0) {
+      const featured = products.filter((p) => p.isFeatured);
+      const source = featured.length ? featured : products;
+      return source.slice(0, 4).map((p) => ({
+        id: p.id,
+        image: p.image,
+        title: p.title,
+        sub: p.description || 'Handcrafted jewellery for your special day',
+        offerLabel: '',
+        offerPrice: null,
+        originalPrice: null,
+        productLink: '',
+        ctaText: 'Shop Now',
+      }));
+    }
+    return HD_HERO_FALLBACK;
+  }, [carouselItems, products]);
 
   // Auto-advance carousel
   useEffect(() => {
@@ -231,17 +279,40 @@ export default function HomePage() {
             className="max-w-2xl rounded-[2.6rem] border border-white/30 bg-white/75 p-8 backdrop-blur-sm sm:p-12 shadow-xl"
           >
             <p className="luxury-serif text-xs uppercase tracking-[0.45em] text-[#9b7a48]">Aurakriti Collection</p>
+
+            {/* Offer badge */}
+            {heroSlides[heroIndex]?.offerLabel && (
+              <span className="mt-3 inline-block rounded-full bg-[#c9a14a] px-4 py-1 text-xs font-bold uppercase tracking-widest text-white shadow">
+                {heroSlides[heroIndex].offerLabel}
+              </span>
+            )}
+
             <h1 className="luxury-serif mt-5 text-4xl leading-tight text-[#2f241b] sm:text-6xl">
               {heroSlides[heroIndex]?.title || 'Timeless Elegance'}
             </h1>
             <p className="mt-5 text-base leading-8 text-[#6b5645] sm:text-lg">
               {heroSlides[heroIndex]?.sub || 'Discover handcrafted jewellery designed for modern grace'}
             </p>
+
+            {/* Price display */}
+            {heroSlides[heroIndex]?.offerPrice != null && (
+              <div className="mt-4 flex items-baseline gap-3">
+                <span className="text-2xl font-bold text-[#c9a14a]">
+                  ₹{Number(heroSlides[heroIndex].offerPrice).toLocaleString('en-IN')}
+                </span>
+                {heroSlides[heroIndex]?.originalPrice != null && (
+                  <span className="text-base text-gray-400 line-through">
+                    ₹{Number(heroSlides[heroIndex].originalPrice).toLocaleString('en-IN')}
+                  </span>
+                )}
+              </div>
+            )}
+
             <a
-              href="#products"
+              href={heroSlides[heroIndex]?.productLink || '#products'}
               className="mt-8 inline-flex rounded-full bg-[#c9a14a] px-8 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-[#b88f37] shadow-lg"
             >
-              Shop Now
+              {heroSlides[heroIndex]?.ctaText || 'Shop Now'}
             </a>
           </motion.div>
         </div>

--- a/Aurakriti/src/models/Carousel.js
+++ b/Aurakriti/src/models/Carousel.js
@@ -1,0 +1,61 @@
+import mongoose from 'mongoose';
+
+const carouselSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: [true, 'Title is required'],
+      trim: true,
+    },
+    subtitle: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    image: {
+      type: String,
+      required: [true, 'Image URL is required'],
+    },
+    imagePublicId: {
+      type: String,
+      default: '',
+    },
+    offerLabel: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    offerPrice: {
+      type: Number,
+      default: null,
+    },
+    originalPrice: {
+      type: Number,
+      default: null,
+    },
+    productLink: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    ctaText: {
+      type: String,
+      trim: true,
+      default: 'Shop Now',
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+    order: {
+      type: Number,
+      default: 0,
+    },
+  },
+  { timestamps: true }
+);
+
+carouselSchema.index({ isActive: 1, order: 1 });
+
+const Carousel = mongoose.models.Carousel || mongoose.model('Carousel', carouselSchema);
+export default Carousel;


### PR DESCRIPTION
- Add Carousel mongoose model with title, subtitle, image, offerLabel, offerPrice, originalPrice, productLink, ctaText, isActive, order fields
- Add public GET /api/carousel route for frontend consumption
- Add admin CRUD /api/admin/carousel (GET/POST/PATCH/DELETE) protected with requireRole(['admin'])
- Support both multipart/form-data (Cloudinary upload) and JSON (URL) for image input
- Add /admin/carousel page with full management UI: create, edit, toggle active, delete, image preview
- Add /admin/layout.js with sidebar nav including Carousel link
- Update /admin/dashboard to link Products and Carousel cards
- Update homepage carousel to fetch from /api/carousel with priority: DB items > product images > static fallback
- Carousel slides now render offer badge, dynamic price, original price strikethrough, and custom CTA link