### PR TITLE
fix: admin orders exposure and payment verify race (#57)

### DIFF
--- a/Aurakriti/src/app/api/orders/route.js
+++ b/Aurakriti/src/app/api/orders/route.js
@@ -23,6 +23,13 @@ export async function GET(request) {
     return NextResponse.json({ success: false, message: 'Invalid view parameter.' }, { status: 400 });
   }
 
+  if (auth.user.role === 'admin') {
+    return NextResponse.json(
+      { success: false, message: 'Admins must use /api/admin/orders for order listing.' },
+      { status: 403 }
+    );
+  }
+
   const query = {};
   if (auth.user.role === 'user' || view === 'user') {
     query.user = auth.user._id;

--- a/Aurakriti/src/app/api/payment/verify/route.js
+++ b/Aurakriti/src/app/api/payment/verify/route.js
@@ -81,10 +81,62 @@ export async function POST(request) {
       return NextResponse.json({ success: false, message: 'Invalid payment order reference.' }, { status: 400 });
     }
 
-    session.paymentAttempts = Number(session.paymentAttempts || 0) + 1;
-    await session.save();
+    const sessionFilter = isObjectId
+      ? { _id: orderId, user: auth.user._id, status: 'created' }
+      : { razorpayOrderId: orderId, user: auth.user._id, status: 'created' };
 
-    const verification = session.verificationMode === 'mock'
+    const lockedSession = await PaymentSession.findOneAndUpdate(
+      sessionFilter,
+      { $set: { status: 'processing' }, $inc: { paymentAttempts: 1 } },
+      { new: true }
+    );
+
+    if (!lockedSession) {
+      const current = await PaymentSession.findOne(
+        isObjectId ? { _id: orderId, user: auth.user._id } : { razorpayOrderId: orderId, user: auth.user._id }
+      );
+
+      if (current?.status === 'paid') {
+        if (current.paymentId && current.paymentId !== razorpay_payment_id) {
+          return NextResponse.json(
+            { success: false, message: 'Payment already verified with a different payment id.' },
+            { status: 409 }
+          );
+        }
+
+        const existingOrder = current.order ? await Order.findById(current.order).populate(orderPopulateConfig) : null;
+        if (!existingOrder) {
+          return NextResponse.json(
+            { success: false, message: 'Payment is verified but order record is missing.' },
+            { status: 409 }
+          );
+        }
+
+        return NextResponse.json({
+          success: true,
+          message: 'Payment already verified for this checkout session.',
+          data: {
+            ...mapOrder(existingOrder, auth.user),
+            paymentId: existingOrder.paymentDetails?.razorpayPaymentId || razorpay_payment_id,
+            status: existingOrder.paymentStatus,
+          },
+        });
+      }
+
+      if (current?.status === 'processing') {
+        return NextResponse.json(
+          { success: false, message: 'Payment is already being processed. Please wait.' },
+          { status: 409 }
+        );
+      }
+
+      return NextResponse.json(
+        { success: false, message: 'Payment session is not available for verification.' },
+        { status: 409 }
+      );
+    }
+
+    const verification = lockedSession.verificationMode === 'mock'
       ? { valid: true, mode: 'mock' }
       : verifyPaymentSignature({
       orderId: razorpay_order_id,
@@ -93,45 +145,53 @@ export async function POST(request) {
     });
 
     if (!verification.valid) {
-      session.status = 'failed';
-      session.paymentFailureReason = 'Invalid Razorpay signature';
-      await session.save();
+      lockedSession.status = 'failed';
+      lockedSession.paymentFailureReason = 'Invalid Razorpay signature';
+      await lockedSession.save();
       return NextResponse.json({ success: false, message: 'Payment verification failed.' }, { status: 400 });
     }
 
-    const { order: createdOrder } = await createOrderFromData({
-      userId: auth.user._id,
-      items: session.items,
-      shippingAddress: session.shippingAddress,
-      amounts: {
-        subtotal: session.subtotal,
-        shippingFee: session.shippingFee,
-        totalAmount: session.totalAmount,
-      },
-      method: 'online',
-      paymentDetails: {
-        razorpayOrderId: session.razorpayOrderId,
-        mode: verification.mode,
-      },
-    });
+    let populatedOrder;
+    try {
+      const { order: createdOrder } = await createOrderFromData({
+        userId: auth.user._id,
+        items: lockedSession.items,
+        shippingAddress: lockedSession.shippingAddress,
+        amounts: {
+          subtotal: lockedSession.subtotal,
+          shippingFee: lockedSession.shippingFee,
+          totalAmount: lockedSession.totalAmount,
+        },
+        method: 'online',
+        paymentDetails: {
+          razorpayOrderId: lockedSession.razorpayOrderId,
+          mode: verification.mode,
+        },
+      });
 
-    const populatedOrder = await finalizeOrderPayment({
-      order: createdOrder,
-      payment: {
-        razorpay_order_id,
-        razorpay_payment_id,
-        razorpay_signature,
-      },
-      verificationMode: verification.mode,
-      isCOD: false,
-    });
+      populatedOrder = await finalizeOrderPayment({
+        order: createdOrder,
+        payment: {
+          razorpay_order_id,
+          razorpay_payment_id,
+          razorpay_signature,
+        },
+        verificationMode: verification.mode,
+        isCOD: false,
+      });
+    } catch (orderError) {
+      lockedSession.status = 'failed';
+      lockedSession.paymentFailureReason = orderError.message || 'Order creation failed';
+      await lockedSession.save();
+      throw orderError;
+    }
 
-    session.status = 'paid';
-    session.paymentId = razorpay_payment_id;
-    session.signature = razorpay_signature;
-    session.order = populatedOrder._id;
-    session.paymentFailureReason = '';
-    await session.save();
+    lockedSession.status = 'paid';
+    lockedSession.paymentId = razorpay_payment_id;
+    lockedSession.signature = razorpay_signature;
+    lockedSession.order = populatedOrder._id;
+    lockedSession.paymentFailureReason = '';
+    await lockedSession.save();
 
     let invoiceMeta = null;
     try {
@@ -158,7 +218,7 @@ export async function POST(request) {
     const orderCode = String(populatedOrder._id).slice(-8).toUpperCase();
     sendEmail(
       auth.user.email,
-      `Payment Successful #${orderCode} - EcoCommerce`,
+      `Payment Successful #${orderCode} - Aurakriti`,
       `
         <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;background:#f8fafb;padding:24px;border-radius:16px">
           <h2 style="color:#1e293b">Payment Successful</h2>
@@ -174,7 +234,7 @@ export async function POST(request) {
       const appUrl = getAppUrl();
       sendEmail(
         auth.user.email,
-        `Invoice #${orderCode} - EcoCommerce`,
+        `Invoice #${orderCode} - Aurakriti`,
         `<p>Your invoice is ready. <a href="${appUrl}${invoiceMeta.publicUrl}">Download Invoice PDF</a></p>`
       ).catch((error) => console.error('Invoice email error:', error.message));
     }

--- a/Aurakriti/src/models/PaymentSession.js
+++ b/Aurakriti/src/models/PaymentSession.js
@@ -87,7 +87,7 @@ const paymentSessionSchema = new mongoose.Schema(
     },
     status: {
       type: String,
-      enum: ['created', 'paid', 'failed', 'expired'],
+      enum: ['created', 'processing', 'paid', 'failed', 'expired'],
       default: 'created',
       index: true,
     },


### PR DESCRIPTION
## Summary

- Block admins from `GET /api/orders` (returns 403); admin UI already uses paginated `/api/admin/orders`
- Add atomic `created` → `processing` session lock in payment verify to prevent duplicate orders on parallel requests
- Add `processing` status to `PaymentSession` schema
- Fix payment success/invoice email branding: EcoCommerce → Aurakriti

Closes #57

## Test plan

- [ ] As admin, `GET /api/orders` returns 403 with message to use `/api/admin/orders`
- [ ] As admin, `/api/admin/orders` still lists orders with pagination
- [ ] As user, `GET /api/orders?view=user` returns only own orders
- [ ] Complete online checkout; verify single order created per payment
- [ ] Send two parallel `POST /api/payment/verify` for same session; second returns 409
- [ ] Retry verify after success returns idempotent paid response
- [ ] Payment success email subject shows Aurakriti